### PR TITLE
Update app to build with sdk 1.3 f7

### DIFF
--- a/helpers/ble_serial.c
+++ b/helpers/ble_serial.c
@@ -50,11 +50,7 @@ static void ble_profile_serial_stop(FuriHalBleProfileBase* profile) {
 #define CONNECTION_INTERVAL_MAX (0x24)
 
 static const GapConfig serial_template_config = {
-    .adv_service =
-        {
-            .UUID_Type = UUID_TYPE_16,
-            .Service_UUID_16 = 0x3080,
-        },
+    .adv_service_uuid = 0x3080,
     .appearance_char = 0x8600,
     .bonding_mode = true,
     .pairing_method = GapPairingPinCodeShow,
@@ -94,8 +90,8 @@ static void
         clicker_str,
         furi_hal_version_get_name_ptr());
 
-    config->adv_service.UUID_Type = UUID_TYPE_16;
-    config->adv_service.Service_UUID_16 |= furi_hal_version_get_hw_color();
+    config->adv_service_uuid = UUID_TYPE_16;
+    config->adv_service_uuid |= furi_hal_version_get_hw_color();
 }
 
 static const FuriHalBleProfileTemplate profile_callbacks = {


### PR DESCRIPTION
**Replace deprecated `adv_service` with `adv_service_uuid`**

This update replaces all references to the deprecated `adv_service` field with the new `adv_service_uuid field` of `GapConfig`

Since `adv_service_uuid `s now a uint16_t, there's no longer a need to specify the UUID type explicitly—simplifying the BLE serial configuration.

This change ensures compatibility with SDK 1.3 for the F7 platform and allows the app to build successfully.